### PR TITLE
Ticket 49- Fixing login not redirecting bug

### DIFF
--- a/backend/src/main/java/com/example/users/controller/UserController.java
+++ b/backend/src/main/java/com/example/users/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.users.controller;
 
 import com.example.users.dto.CreateUserResponseDTO;
+import com.example.users.dto.LoginUserRequestDTO;
 import com.example.users.dto.LoginUserResponseDTO;
 import com.example.config.JwtConfig;
 import com.example.users.dto.CreateUserRequestDTO;
@@ -37,9 +38,9 @@ public class UserController {
     }
 
     /**
-     * Handles user login requests via HTTP GET with credentials passed in request headers.
+     * Handles user login requests via HTTP POST with credentials passed in request body.
      *
-     * Expected headers:
+     * Expected body:
      * 
      *   email - The user's email address (required).
      *   password - The user's password (required).
@@ -47,18 +48,22 @@ public class UserController {
      *
      * Validates the provided credentials and returns a {@link LoginUserResponseDTO}
      * containing the user's ID and a generated JWT token if authentication is successful.
+     * Passing in the loginUserRequestDTO object as a parameter ensures that the request body is properly mapped and validated.
      *
-     * @param email    the user's email address from the "email" request header
-     * @param password the user's password from the "password" request header
+     * @param email    the user's email address from the "email" request body
+     * @param password the user's password from the "password" request body
      * @return {@link ResponseEntity} containing {@link LoginUserResponseDTO} on success
      */
-    @GetMapping("/login")
+    @PostMapping("/login")
     public ResponseEntity<LoginUserResponseDTO> loginUser(
-            @Valid @RequestHeader("email") String email,
-            @RequestHeader("password") String password,
+            @Valid @RequestBody LoginUserRequestDTO loginUserRequestDTO,
             HttpServletResponse response) {
 
-        LoginUserResponseDTO userIdAndJWT = this.userService.validateUserCredentials(email, password, response);
+        LoginUserResponseDTO userIdAndJWT = this.userService.validateUserCredentials(
+                loginUserRequestDTO.getEmail(),
+                loginUserRequestDTO.getPassword(),
+                response
+        );
 
         return ResponseEntity.ok(userIdAndJWT);
     }

--- a/backend/src/main/java/com/example/users/dto/LoginUserResponseDTO.java
+++ b/backend/src/main/java/com/example/users/dto/LoginUserResponseDTO.java
@@ -24,7 +24,7 @@ public class LoginUserResponseDTO {
         return token;
     }
 
-    public void setTokne(String token) {
+    public void setToken(String token) {
         this.token = token;
     }
 }

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -5,23 +5,26 @@ import RegisterForm from "../RegisterForm/RegisterForm";
 import { useAuth } from "../../context/AuthContext.jsx";
 
 export default function LoginForm() {
-  const { setUserId } = useAuth();
+  const { setUserId, setIsAuthenticated } = useAuth();
   const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [fetchStatusMsg, setFetchStatusMsg] = useState("");
 
+
   const handleLoginClick = async () => {
     setFetchStatusMsg("Verifying... please wait");
 
     const response = await fetch("http://localhost:8080/users/login", {
-      method: "GET",
+      method: "POST",
       headers: {
         "Content-Type": "application/json",
-        email: email,
-        password: password,
       },
       credentials: "include",
+      body: JSON.stringify({
+        email: email,
+        password: password,
+      }),
     });
 
     if (!response.ok) {
@@ -29,11 +32,15 @@ export default function LoginForm() {
       return;
     }
 
-    const data = await response.json();
-    setUserId(data["userId"]);
-    setFetchStatusMsg("Correct credentials, redirecting...");
-    await new Promise((resolve) => setTimeout(resolve, 1250));
-    navigate("/main", { replace: true });
+    if (response.ok) {
+      const data = await response.json();
+      setUserId(data["userId"]);
+      setIsAuthenticated(true);
+      setFetchStatusMsg("Correct credentials, redirecting...");
+      // slight delay to show user the success message
+      await new Promise((resolve) => setTimeout(resolve, 1250));
+      navigate("/main", { replace: true });
+    }
   };
 
   return (

--- a/frontend/src/components/RegisterForm/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm/RegisterForm.jsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useAuth } from "../../context/AuthContext";
 
 function FullScreenModal({ onClose }) {
-  const { setUserId, setIsAuthenticated } = useAuth();
+  const { setUserId } = useAuth();
   const [formData, setFormData] = useState({
     firstName: "",
     lastName: "",
@@ -44,7 +44,6 @@ function FullScreenModal({ onClose }) {
 
       const data = response.json();
       setUserId(data["userId"]);
-      setIsAuthenticated(true);
       setStatus("Successfully registered!");
       
     } catch (error) {

--- a/frontend/src/components/RegisterForm/RegisterForm.jsx
+++ b/frontend/src/components/RegisterForm/RegisterForm.jsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useAuth } from "../../context/AuthContext";
 
 function FullScreenModal({ onClose }) {
-  const { setUserId } = useAuth();
+  const { setUserId, setIsAuthenticated } = useAuth();
   const [formData, setFormData] = useState({
     firstName: "",
     lastName: "",
@@ -44,6 +44,7 @@ function FullScreenModal({ onClose }) {
 
       const data = response.json();
       setUserId(data["userId"]);
+      setIsAuthenticated(true);
       setStatus("Successfully registered!");
       
     } catch (error) {

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -39,7 +39,7 @@ export const AuthProvider = ({ children }) => {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, validateToken, userId, setUserId }}>
+    <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated, validateToken, userId, setUserId }}>
       {!loading && children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
Updated frontend to properly set the isAuthenticated useState for the useAuth() context. Private route for login was dependent on if isAuthenticated is true, so had to pass in setIsAuthenticated useStates to the login form. Made it so that when the backend returns a 200 for /login api, then setIsAuthenticaed is set to True so that the private routes will allow the redirect to the home page. 
Also updated backend to make the /login api a POST request instead of a GET request. Standard practice is using a POST call so that the email and password are not exposed in the headers. Passing data in the body adds a layer of protection.